### PR TITLE
Updated Metasploit Link

### DIFF
--- a/mona.py
+++ b/mona.py
@@ -1771,7 +1771,7 @@ def getSkeletonHeader(exploittype,portnr,extension,url,badchars='\x00\x0a\x0d'):
 	skeletonheader += "##\n\n"
 	skeletonheader += "require 'msf/core'\n\n"
 	skeletonheader += "class MetasploitModule < Msf::Exploit::Remote\n"
-	skeletonheader += "  #Rank definition: http://dev.metasploit.com/redmine/projects/framework/wiki/Exploit_Ranking\n"
+	skeletonheader += "  #Rank definition: https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking\n"
 	skeletonheader += "  #ManualRanking/LowRanking/AverageRanking/NormalRanking/GoodRanking/GreatRanking/ExcellentRanking\n"
 	skeletonheader += "  Rank = NormalRanking\n\n"
 	


### PR DESCRIPTION
Hi Peter, as Metasploit has [decommissioned Redmine](https://github.com/rapid7/metasploit-framework/wiki/Decommissioning-Redmine), I've updated the link of the `Rank Definition`; it is now pointing to the new Github Wiki.

It's just a small improvement :)