### PR TITLE
Fix Symbols Loading

### DIFF
--- a/mona.py
+++ b/mona.py
@@ -2945,7 +2945,6 @@ class MnModule:
 				try:
 					themod = dbg.getModule(self.moduleKey)
 					syms = themod.getSymbols()
-					syms = []
 					thename = ""
 					for sym in syms:
 						if syms[sym].getType().startswith("Import"):


### PR DESCRIPTION
For some reason, the symbols were removed after fetching using `syms = []`, idk the original reason for this, but removing it seems to fix some weird cases when generating rop chains 